### PR TITLE
IConfiguration based settings to add multiple gateways (#24)

### DIFF
--- a/samples/HttpGateway/Startup.cs
+++ b/samples/HttpGateway/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
+using System.Collections.Generic;
 
 namespace HttpGateway
 {
@@ -65,6 +66,9 @@ namespace HttpGateway
         /// </summary>
         private void ConfigureHttpServiceGateways(IApplicationBuilder app)
         {
+            // ---------------------
+            // Samples for configuring a single gateway instance
+
             // this would forward every request to the service. this way, your application can only handle one service.
 
             //app.RunHttpServiceGateway("fabric:/GatewaySample/HttpService");
@@ -73,11 +77,16 @@ namespace HttpGateway
 
             app.RunHttpServiceGateway("/service1", "fabric:/GatewaySample/HttpService");
 
-            // ... pass an instance of HttpServiceGatewayOptions for more options (e.g. to define the PartitionKeyResolver)
+            // ... pass an instance of HttpServiceGatewayOptions for more options (e.g. to define the ServicePartitionKeyResolver)
 
             //app.RunHttpServiceGateway("/service", new HttpServiceGatewayOptions
             //{
-            //    ServiceName = new Uri("fabric:/GatewaySample/HttpService")
+            //    ServiceName = new Uri("fabric:/GatewaySample/HttpService"),
+            //    ServicePartitionKeyResolver = (context) =>
+            //    {
+            //        string namedPartitionKey = context.Request.Query["partitionKey"];
+            //        return new ServicePartitionKey(namedPartitionKey);
+            //    }
             //});
 
             // ... if you need to do multiple things within the path branch, you can use app.Map():
@@ -89,6 +98,20 @@ namespace HttpGateway
             //        ServiceName = new Uri("fabric:/GatewaySample/HttpService")
             //    });
             //});
+
+            // ---------------------
+            // Samples for configuring many gateway instances
+
+            // this configures one or many gateway instances based on the Configuration system (e.g. file-based).
+            app.RunHttpServiceGateways(Configuration.GetSection("GatewayServices"));
+
+            // this configures one or many gateway instances based on a list of configuration entries.
+            var services = new List<HttpServiceGatewayConfigurationEntry>
+            {
+                new HttpServiceGatewayConfigurationEntry("/another-service1", "fabric:/MyApp/AnotherService1"),
+                new HttpServiceGatewayConfigurationEntry("/another-service2", "fabric:/MyApp/AnotherService2", "OwinListener")
+            };
+            app.RunHttpServiceGateways(services);
         }
 
         public static void Main(string[] args)

--- a/samples/HttpGateway/appsettings.json
+++ b/samples/HttpGateway/appsettings.json
@@ -2,5 +2,17 @@
   "HttpCommunication": {
     "MaxRetryCount": 8,
     "OperationTimeout": "00:00:15"
-  }
+  },
+
+  "GatewayServices": [
+    {
+      "PathMatch": "/some-service1",
+      "ServiceName": "fabric:/MyApp/SomeService1"
+    },
+    {
+      "PathMatch": "/some-service2",
+      "ServiceName": "fabric:/MyApp/SomeService2",
+      "ListenerName": "OwinListener"
+    }
+  ] 
 }

--- a/src/C3.ServiceFabric.HttpServiceGateway/HttpServiceGatewayConfigurationEntry.cs
+++ b/src/C3.ServiceFabric.HttpServiceGateway/HttpServiceGatewayConfigurationEntry.cs
@@ -1,0 +1,35 @@
+namespace C3.ServiceFabric.HttpServiceGateway
+{
+    /// <summary>
+    /// Represents one entry in a <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>-based
+    /// configuration of the gateway.
+    /// </summary>
+    public class HttpServiceGatewayConfigurationEntry
+    {
+        /// <summary>
+        /// The path on the gateway that should be used for forwarding requests to the service.
+        /// </summary>
+        public string PathMatch { get; set; }
+
+        /// <summary>
+        /// Name of the service within Service Fabric.
+        /// </summary>
+        public string ServiceName { get; set; }
+
+        /// <summary>
+        /// Name of the listener in the replica or instance to which the client should connect.
+        /// </summary>
+        public string ListenerName { get; set; }
+
+        public HttpServiceGatewayConfigurationEntry()
+        {
+        }
+
+        public HttpServiceGatewayConfigurationEntry(string pathMatch, string serviceName, string listenerName = null)
+        {
+            PathMatch = pathMatch;
+            ServiceName = serviceName;
+            ListenerName = listenerName;
+        }
+    }
+}

--- a/src/C3.ServiceFabric.HttpServiceGateway/project.json
+++ b/src/C3.ServiceFabric.HttpServiceGateway/project.json
@@ -21,6 +21,7 @@
     "C3.ServiceFabric.HttpCommunication": "1.0.0-*",
 
     "Microsoft.AspNetCore.Http.Abstractions": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.Binder": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-final"
   },
 


### PR DESCRIPTION
PR for #24 

file-based config would look like this:

``` json
{
  "GatewayServices": [
    {
      "PathMatch": "/some-service1",
      "ServiceName": "fabric:/MyApp/SomeService1"
    },
    {
      "PathMatch": "/some-service2",
      "ServiceName": "fabric:/MyApp/SomeService2",
      "ListenerName": "OwinListener"
    }
  ] 
}
```

Startup.cs - ConfigureServices: `app.RunHttpServiceGateways(Configuration.GetSection("GatewayServices"));`

of course, this information could also come from a database, ...

the downside of this is that it doesn't allow you to specify a `ServicePartitionKeyResolver` since this must be a delegate. However, I guess people will be happy to use the existing `RunHttpServiceGateway` in that case anyway.

@wmccullough thoughts?
