### PR TITLE
New HTTP-404 retry behavior; HTTP-5xx retries off by default

### DIFF
--- a/samples/HttpService/Controllers/FailuresController.cs
+++ b/samples/HttpService/Controllers/FailuresController.cs
@@ -21,5 +21,14 @@ namespace HttpService.Controllers
             await Task.Delay(TimeSpan.FromSeconds(seconds));
             return $"Response after {seconds} seconds";
         }
+
+        [Route("NotFoundWithHeader")]
+        [HttpGet]
+        public IActionResult NotFoundWithHeader()
+        {
+            Response.Headers["X-ServiceFabric"] = "ResourceNotFound";
+
+            return NotFound();
+        }
     }
 }

--- a/src/C3.ServiceFabric.HttpCommunication/HttpCommunicationDefaults.cs
+++ b/src/C3.ServiceFabric.HttpCommunication/HttpCommunicationDefaults.cs
@@ -20,7 +20,7 @@ namespace C3.ServiceFabric.HttpCommunication
         /// <summary>
         /// Defines whether certain status codes from the response should be retried. (eg. 500)
         /// </summary>
-        public static bool RetryHttpStatusCodeErrors = true;
+        public static bool RetryHttpStatusCodeErrors = false;
 
         /// <summary>
         /// The number of times a service request is retried in case of an error.


### PR DESCRIPTION
This PR changes the retry behavior:

**HTTP 404** responses now follow the official Service Fabric reverse proxy: They are always retried unless the response contains the `X-ServiceFabric: ResourceNotFound` header. This means that the gateway now works correctly when services use the [ServiceFabricReverseProxyIntegrationMiddleware](https://github.com/Azure/service-fabric-aspnetcore/blob/develop/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricReverseProxyIntegrationMiddleware.cs) from `Microsoft.ServiceFabric.AspNetCore`.

**HTTP 5xx** responses are no longer retried by default since this is just too dangerous without more detailed control mechanisms (like e.g. only retry 500 for HTTP GET). The retries can still be enabled by setting `HttpCommunicationOptions.RetryHttpStatusCodeErrors` to `true`.