### PR TITLE
Add GatewayOptions.ShouldForwardCookies to enable forwarding of cookies to downstream services

### DIFF
--- a/samples/HttpDirect/DirectCommunicationMiddleware.cs
+++ b/samples/HttpDirect/DirectCommunicationMiddleware.cs
@@ -33,7 +33,7 @@ namespace HttpDirect
             {
                 HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, "api/values");
 
-                HttpResponseMessage response = await x.HttpClient.SendAsync(req, context.RequestAborted);
+                HttpResponseMessage response = await x.SendAsync(req, context.RequestAborted, false);
 
                 await context.Response.WriteAsync(DateTime.Now + " - Result from API: ");
                 await context.Response.WriteAsync("Status: " + response.StatusCode + "; Body: ");

--- a/src/C3.ServiceFabric.HttpCommunication/HttpCommunicationClient.cs
+++ b/src/C3.ServiceFabric.HttpCommunication/HttpCommunicationClient.cs
@@ -13,9 +13,9 @@ namespace C3.ServiceFabric.HttpCommunication
     /// </summary>
     public class HttpCommunicationClient : ICommunicationClient, IDisposable
     {
-        public HttpClient HttpClient { get; }
+        private HttpClient HttpClient { get; }
 
-        public HttpClient HttpClientWithCookieForwarding { get; }
+        private HttpClient HttpClientWithCookieForwarding { get; }
 
         /// <summary>
         /// The resolved service partition which contains the resolved service endpoints.
@@ -53,6 +53,15 @@ namespace C3.ServiceFabric.HttpCommunication
             var client = shouldForwardCookies ? HttpClientWithCookieForwarding : HttpClient;
             return client.SendAsync(request, cancellationToken);
         }
+
+        /// <summary>
+        /// Validates this <see cref="HttpCommunicationClient"/> against the given <see cref="baseAddress"/>
+        /// </summary>
+        /// <param name="baseAddress"></param>
+        /// <returns></returns>
+        public bool Validate(Uri baseAddress) =>
+            HttpClient.BaseAddress == baseAddress &&
+            HttpClientWithCookieForwarding.BaseAddress == baseAddress;
 
         public void Dispose()
         {

--- a/src/C3.ServiceFabric.HttpCommunication/HttpCommunicationClientFactory.cs
+++ b/src/C3.ServiceFabric.HttpCommunication/HttpCommunicationClientFactory.cs
@@ -64,7 +64,7 @@ namespace C3.ServiceFabric.HttpCommunication
             _logger.ValidateClient(client, endpoint);
 
             Uri endpointUri = CreateEndpointUri(endpoint);
-            bool equals = client != null && client.HttpClient.BaseAddress == endpointUri;
+            bool equals = client?.Validate(endpointUri) ?? false; 
             return equals;
         }
 

--- a/src/C3.ServiceFabric.HttpCommunication/HttpCommunicationServiceCollectionExtensions.cs
+++ b/src/C3.ServiceFabric.HttpCommunication/HttpCommunicationServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace C3.ServiceFabric.HttpCommunication
 
             services.AddTransient(x => ServicePartitionResolver.GetDefault());
             services.AddTransient<IExceptionHandler, HttpCommunicationExceptionHandler>();
-            services.AddScoped<IHttpCommunicationClientFactory, HttpCommunicationClientFactory>();
+            services.AddSingleton<IHttpCommunicationClientFactory, HttpCommunicationClientFactory>();
 
             return services;
         }

--- a/src/C3.ServiceFabric.HttpCommunication/HttpCommunicationServiceCollectionExtensions.cs
+++ b/src/C3.ServiceFabric.HttpCommunication/HttpCommunicationServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace C3.ServiceFabric.HttpCommunication
 
             services.AddTransient(x => ServicePartitionResolver.GetDefault());
             services.AddTransient<IExceptionHandler, HttpCommunicationExceptionHandler>();
-            services.AddSingleton<IHttpCommunicationClientFactory, HttpCommunicationClientFactory>();
+            services.AddScoped<IHttpCommunicationClientFactory, HttpCommunicationClientFactory>();
 
             return services;
         }

--- a/src/C3.ServiceFabric.HttpServiceGateway/HttpServiceGatewayMiddleware.cs
+++ b/src/C3.ServiceFabric.HttpServiceGateway/HttpServiceGatewayMiddleware.cs
@@ -110,9 +110,9 @@ namespace C3.ServiceFabric.HttpServiceGateway
 
             req.CopyHeadersFromCurrentContext(context);
             req.AddProxyHeaders(context);
-
-
+            
             // execute request
+
             HttpResponseMessage response;
             try
             {

--- a/src/C3.ServiceFabric.HttpServiceGateway/HttpServiceGatewayMiddleware.cs
+++ b/src/C3.ServiceFabric.HttpServiceGateway/HttpServiceGatewayMiddleware.cs
@@ -111,12 +111,12 @@ namespace C3.ServiceFabric.HttpServiceGateway
             req.CopyHeadersFromCurrentContext(context);
             req.AddProxyHeaders(context);
 
-            // execute request
 
+            // execute request
             HttpResponseMessage response;
             try
             {
-                response = await client.HttpClient.SendAsync(req, context.RequestAborted);
+                response = await client.SendAsync(req, context.RequestAborted, _gatewayOptions.ShouldForwardCookies);
             }
             catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
             {

--- a/src/C3.ServiceFabric.HttpServiceGateway/HttpServiceGatewayOptions.cs
+++ b/src/C3.ServiceFabric.HttpServiceGateway/HttpServiceGatewayOptions.cs
@@ -34,5 +34,10 @@ namespace C3.ServiceFabric.HttpServiceGateway
         /// Defines the retry behavior of the <see cref="ServicePartitionClient{TCommunicationClient}"/>.
         /// </summary>
         public OperationRetrySettings RetrySettings { get; set; } = new OperationRetrySettings();
+
+        /// <summary>
+        /// Defines whether cookies should be forwarded on to the service with the request
+        /// </summary>
+        public bool ShouldForwardCookies { get; set; } = false; // Default to false for backwards compat, but should probably default to true?
     }
 }


### PR DESCRIPTION
I added `bool HttpServiceGatewayOptions.ShouldForwardCookies` which can be set when configuring each service in the gateway to indicate whether cookies should be forwarded in requests to the given service.

By default cookies are not forwarded.  I need this functionality to support cookie-based authentication in my ASP.Net Core web app.  I think that they should be forwarded by default, but I left the default as-is so as not to break backward compatibility.

This addresses issue 46 (https://github.com/c3-ls/ServiceFabric-Http/issues/46).